### PR TITLE
GPB-21 Add enum deserializers

### DIFF
--- a/src/main/kotlin/de/genpare/modules/DataManagement.kt
+++ b/src/main/kotlin/de/genpare/modules/DataManagement.kt
@@ -21,8 +21,8 @@ import org.jetbrains.exposed.sql.AndOp
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
 
-suspend fun checkJobTitleLength(context: PipelineContext<Unit, ApplicationCall>, jobTitle: String?) =
-    if ((jobTitle?.length ?: 64) > 63) {
+suspend fun checkJobTitleLength(context: PipelineContext<Unit, ApplicationCall>, jobTitle: String) =
+    if (jobTitle.length > 63) {
         context.call.respond(
             HttpStatusCode.BadRequest,
             "Job title mustn't be longer than 63 characters."
@@ -148,7 +148,8 @@ fun Application.dataManagement() {
                         return@patch
                     }
 
-                    checkJobTitleLength(this, data.jobTitle) ?: return@patch
+                    if (data.jobTitle != null)
+                        checkJobTitleLength(this, data.jobTitle) ?: return@patch
 
                     val newSalary = transaction {
                         if (data.salary != null) salary.salary = data.salary

--- a/src/main/kotlin/de/genpare/modules/MemberManagement.kt
+++ b/src/main/kotlin/de/genpare/modules/MemberManagement.kt
@@ -1,13 +1,15 @@
 package de.genpare.modules
 
-import de.genpare.data.dtos.*
+import de.genpare.data.dtos.DeleteDTO
+import de.genpare.data.dtos.MemberDTO
+import de.genpare.data.dtos.NameChangeDTO
+import de.genpare.data.dtos.SessionDTO
+import de.genpare.data.enums.Gender
+import de.genpare.data.enums.State
 import de.genpare.database.entities.Member
 import de.genpare.query.filters.AbstractFilter
 import de.genpare.query.result_transformers.AbstractResultTransformer
-import de.genpare.type_adapters.FilterDeserializer
-import de.genpare.type_adapters.IntRangeSerializer
-import de.genpare.type_adapters.LocalDateTypeAdapter
-import de.genpare.type_adapters.ResultTransformerDeserializer
+import de.genpare.type_adapters.*
 import de.genpare.util.Utils
 import de.genpare.util.Utils.queryParameterOrError
 import de.genpare.util.Utils.receiveOrNull
@@ -28,6 +30,9 @@ fun Application.memberManagement() {
             registerTypeAdapter(AbstractResultTransformer::class.java, ResultTransformerDeserializer)
             registerTypeAdapter(AbstractFilter::class.java, FilterDeserializer)
             registerTypeAdapter(IntRange::class.java, IntRangeSerializer)
+            registerTypeAdapter(Gender::class.java, GenderDeserializer)
+            registerTypeAdapter(LevelOfEducationDeserializer::class.java, LevelOfEducationDeserializer)
+            registerTypeAdapter(State::class.java, StateDeserializer)
 
             serializeNulls()
         }

--- a/src/main/kotlin/de/genpare/type_adapters/GenderDeserializer.kt
+++ b/src/main/kotlin/de/genpare/type_adapters/GenderDeserializer.kt
@@ -1,0 +1,19 @@
+package de.genpare.type_adapters
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import de.genpare.data.enums.Gender
+import java.lang.reflect.Type
+
+object GenderDeserializer : JsonDeserializer<Gender> {
+    override fun deserialize(
+        json: JsonElement,
+        type: Type,
+        context: JsonDeserializationContext
+    ): Gender? {
+        if (json.asString == null) return null
+
+        return Gender.valueOf(json.asString)
+    }
+}

--- a/src/main/kotlin/de/genpare/type_adapters/LevelOfEducationDeserializer.kt
+++ b/src/main/kotlin/de/genpare/type_adapters/LevelOfEducationDeserializer.kt
@@ -1,0 +1,19 @@
+package de.genpare.type_adapters
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import de.genpare.data.enums.LevelOfEducation
+import java.lang.reflect.Type
+
+object LevelOfEducationDeserializer : JsonDeserializer<LevelOfEducation> {
+    override fun deserialize(
+        json: JsonElement,
+        type: Type,
+        context: JsonDeserializationContext
+    ): LevelOfEducation? {
+        if (json.asString == null) return null
+
+        return LevelOfEducation.valueOf(json.asString)
+    }
+}

--- a/src/main/kotlin/de/genpare/type_adapters/StateDeserializer.kt
+++ b/src/main/kotlin/de/genpare/type_adapters/StateDeserializer.kt
@@ -1,0 +1,19 @@
+package de.genpare.type_adapters
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import de.genpare.data.enums.State
+import java.lang.reflect.Type
+
+object StateDeserializer : JsonDeserializer<State> {
+    override fun deserialize(
+        json: JsonElement,
+        type: Type,
+        context: JsonDeserializationContext
+    ): State? {
+        if (json.asString == null) return null
+
+        return State.valueOf(json.asString)
+    }
+}

--- a/src/main/kotlin/de/genpare/util/Utils.kt
+++ b/src/main/kotlin/de/genpare/util/Utils.kt
@@ -24,7 +24,7 @@ object Utils {
     suspend inline fun <reified T : Any> receiveOrNull(context: PipelineContext<Unit, ApplicationCall>): T? =
         try {
             context.call.receive()
-        } catch (e: ContentTransformationException) {
+        } catch (e: Exception) {
             context.call.respond(HttpStatusCode.BadRequest, "Invalid JSON payload.")
             null
         }


### PR DESCRIPTION
GSON doesn't throw an exception if a value isn't in an enum, but just sets it to `null`. The added deserializers actually raise an exception.